### PR TITLE
fix: Using a program variable string

### DIFF
--- a/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
+++ b/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
@@ -59,22 +59,22 @@ expr
     |   it='d2:condition(' WS* stringLiteral WS* ',' expr ',' expr ')'
     |   it='d2:count(' WS* '#{' uid0=UID '.' uid1=UID '}' WS* ')'
     |   it='d2:count(' WS* '#{' programRuleVariableName '}' WS* ')'
-    |   it='d2:count(' WS* stringLiteral WS* ')'
+    |   it='d2:count(' WS* programRuleStringVariableName WS* ')'
     |   it='d2:countIfCondition(' WS* '#{' uid0=UID '.' uid1=UID '}' WS* ',' WS* stringLiteral WS* ')'
     |   it='d2:countIfCondition(' WS* '#{' programRuleVariableName '}' WS* ',' WS* stringLiteral WS* ')'
-    |   it='d2:countIfCondition(' WS* stringLiteral WS* ',' WS* stringLiteral WS* ')'
+    |   it='d2:countIfCondition(' WS* programRuleStringVariableName WS* ',' WS* stringLiteral WS* ')'
     |   it='d2:countIfValue(' WS* '#{' uid0=UID '.' uid1=UID '}' WS* ',' expr ')'
     |   it='d2:countIfValue(' WS* '#{' programRuleVariableName '}' WS* ',' expr ')'
-    |   it='d2:countIfValue(' WS* stringLiteral WS* ',' expr ')'
+    |   it='d2:countIfValue(' WS* programRuleStringVariableName WS* ',' expr ')'
     |   it='d2:countIfZeroPos(' WS* '#{' uid0=UID '.' uid1=UID '}' WS* ')'
     |   it='d2:countIfZeroPos(' WS* '#{' programRuleVariableName '}' WS* ')'
-    |   it='d2:countIfZeroPos(' WS* stringLiteral WS* ')'
+    |   it='d2:countIfZeroPos(' WS* programRuleStringVariableName WS* ')'
     |   it='d2:daysBetween(' expr ',' expr ')'
     |   it='d2:floor(' expr ')'
     |   it='d2:hasUserRole(' expr ')'
     |   it='d2:hasValue(' WS* '#{' uid0=UID '.' uid1=UID '}' WS* ')'
     |   it='d2:hasValue(' WS* '#{' programRuleVariableName '}' WS* ')'
-    |   it='d2:hasValue(' WS* stringLiteral WS* ')'
+    |   it='d2:hasValue(' WS* programRuleStringVariableName WS* ')'
     |   it='d2:hasValue(' WS* 'A{' uid0=UID '}' WS* ')'
     |   it='d2:hasValue(' WS* 'V{' programVariable '}' WS* ')'
     |   it='d2:inOrgUnitGroup(' expr ')'
@@ -83,12 +83,12 @@ expr
     |   it='d2:length(' expr ')'
     |   it='d2:maxValue(' WS* '#{' uid0=UID '.' uid1=UID '}' WS* ')'
     |   it='d2:maxValue(' WS* '#{' programRuleVariableName '}' WS* ')'
-    |   it='d2:maxValue(' WS* stringLiteral WS* ')'
+    |   it='d2:maxValue(' WS* programRuleStringVariableName WS* ')'
     |   it='d2:maxValue(' WS* psEventDate='PS_EVENTDATE:' WS* uid0=UID WS* ')'
     |   it='d2:minutesBetween(' expr ',' expr ')'
     |   it='d2:minValue(' WS* '#{' uid0=UID '.' uid1=UID '}' WS* ')'
     |   it='d2:minValue(' WS* '#{' programRuleVariableName '}' WS* ')'
-    |   it='d2:minValue(' WS* stringLiteral WS* ')'
+    |   it='d2:minValue(' WS* programRuleStringVariableName WS* ')'
     |   it='d2:minValue(' WS* psEventDate='PS_EVENTDATE:' WS* uid0=UID WS* ')'
     |   it='d2:modulus(' expr ',' expr ')'
     |   it='d2:monthsBetween(' expr ',' expr ')'
@@ -169,6 +169,10 @@ programVariable   // (alphabtical)
 
 numericLiteral
     :   NUMERIC_LITERAL
+    ;
+
+programRuleStringVariableName
+    :   stringLiteral
     ;
 
 stringLiteral


### PR DESCRIPTION
We need to define a program rule string variable so the parser is not change to expect a list of string literals instead of one