### PR TITLE
fix: define maven-compiler-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
         <configuration>
           <source>7</source>
           <target>7</target>


### PR DESCRIPTION
Specify version 2.3.2 for maven-compiler-plugin (same version as referenced from dhis2-core). This avoids the following build error when pom.xml is changed:

[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.hisp.dhis.parser:dhis-antlr-expression-parser:jar:1.0.11
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 206, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 


Note that this PR fails the test "Publish - Nexus (pull_request)" on "Release Maven Package". Perhaps this is because 1.0.11 is already published? In the future, should housekeeping PR's like this specify the next -SNAPSHOT version, if we don't need them to be referenced from core or Android?"