### PR TITLE
fix: Compare to div by 0 gives Boolean DHIS2-12089

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <name>DHIS Antlr Expression Parser</name>
   <groupId>org.hisp.dhis.parser</groupId>
-  <version>1.0.19</version>
+  <version>1.0.20-SNAPSHOT</version>
 
   <description>Antlr Expression Parser</description>
 

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrComputeFunction.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrComputeFunction.java
@@ -37,8 +37,10 @@ import java.util.List;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 /**
- * A function that computes the result from the arguments, where if any of the
- * arguments are null or Double.NaN, then the result is null or Double.NaN.
+ * A function that computes the result from expression arguments.
+ * <p>
+ * This abstract class evaluates the expression arguments and makes the
+ * resulting values available to the subclass as a List.
  *
  * @author Jim Grace
  */
@@ -54,7 +56,7 @@ public abstract class AntlrComputeFunction
         {
             Object value = visitor.visit( expr );
 
-            if ( value == null || ( value instanceof Double && Double.isNaN( (Double) value ) ) )
+            if ( invalidArg( value ) )
             {
                 return value;
             }
@@ -63,6 +65,15 @@ public abstract class AntlrComputeFunction
         }
 
         return compute( values );
+    }
+
+    /**
+     * The default for a subclass is that if any of the arguments are null or
+     * Double.NaN, then return null or Double.NaN, respectively.
+     */
+    protected boolean invalidArg( Object value )
+    {
+        return value == null || ( value instanceof Double && Double.isNaN( (Double) value ) );
     }
 
     /**

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompare.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompare.java
@@ -79,4 +79,15 @@ public abstract class AntlrOperatorCompare
             throw new InternalParserException( "trying to compare class " + o1.getClass().getName() );
         }
     }
+
+    /**
+     * For a comparison, if any argument value is null, return null.
+     * (If any arguemnt is Double.NaN, the comparison should proceed and
+     * return a Boolean value.)
+     */
+    @Override
+    protected boolean invalidArg( Object value )
+    {
+        return value == null;
+    }
 }

--- a/src/test/java/org/hisp/dhis/antlr/CompareExpressionTest.java
+++ b/src/test/java/org/hisp/dhis/antlr/CompareExpressionTest.java
@@ -74,6 +74,11 @@ public class CompareExpressionTest
         assertEquals( true, evaluate( "true == 'true'" ) );
     }
 
+    @Test
+    public void testDivideByZero() {
+        assertEquals( false, evaluate( "2 == 2 / 0" ) );
+    }
+
     private Object evaluate(String expression) {
         return Parser.visit( expression, visitor );
     }


### PR DESCRIPTION
### Problem

See [DHIS2-12089](https://jira.dhis2.org/browse/DHIS2-12089). Comparison operators were returning Double.NaN (a numeric value) instead of a Boolean value if one side or the other of the comparison was NaN (which is the result of dividing by zero). While this is the correct result for a mathematical operator that is supposed to return a number, this is not correct for a comparison operator which should always return a Boolean.

This was particularly problematic since any database value is substituted with a dummy value of 0 in the DHIS2 code when finding the description of an expression. Therefore any expression was declared invalid if it included a comparison where one side of the expression included division by a database value.

### Fix

A line in `AntlrComputeFunction` had been returning null or NaN if either argument had this value. This was changed to test using a protected method `invalidArg()` that by default tests for either null or NaN. All numeric operators extend this class directly, and this is the right behaviour for them. `AntlrOperatorCompare` also extends `AntlrComputeFunction`, and it overrides this method to test for null only. All the individual comparison operators extend `AntlrOperatorCompare`, and this is the right behaviour for them.

### Test

A `testDivideByZero()` method was added that failed without the change and succeeds with it.

### Version

For the moment I suggest leaving the version at 1.0.20-SNAPSHOT, because I expect we will want to make some additional fixes in the very near future for new program rule expression problems.