### PR TITLE
fix: Type conversion for comparisons DHIS2-12105

### DIFF
--- a/src/main/java/org/hisp/dhis/antlr/AntlrParserUtils.java
+++ b/src/main/java/org/hisp/dhis/antlr/AntlrParserUtils.java
@@ -188,106 +188,132 @@ public class AntlrParserUtils
      */
     public static Object castClass( Class<?> clazz, Object object )
     {
+        if ( object == null )
+        {
+            return null;
+        }
+
+        if ( clazz == Double.class && makeDouble( object ) != null )
+        {
+            return makeDouble( object );
+        }
+
+        if ( clazz == Boolean.class && makeBoolean( object ) != null )
+        {
+            return makeBoolean( object );
+        }
+
+        if ( clazz == Date.class && makeDate( object ) != null )
+        {
+            return makeDate( object );
+        }
+
+        if ( clazz == String.class )
+        {
+            return makeString( object );
+        }
+
+        throw new ParserExceptionWithoutContext( "Could not cast " + object.getClass().getSimpleName() +
+            " '" + object + "' to " + clazz.getSimpleName() );
+    }
+
+    /**
+     * Makes object a Double, if it can be done.
+     *
+     * @param object object to convert
+     * @return object's Double value, else null
+     */
+    public static Double makeDouble( Object object )
+    {
         if ( object instanceof Double )
         {
-            return castDoubleObject( (Double) object, clazz );
+            return (Double) object;
         }
 
         if ( object instanceof String )
         {
-            return castStringObject( (String) object, clazz );
+            try
+            {
+                return Double.parseDouble( (String) object );
+            }
+            catch ( Exception e )
+            {
+                return null;
+            }
         }
 
+        return null;
+    }
+
+    /**
+     * Makes object a Boolean, if it can be done.
+     *
+     * @param object object to convert
+     * @return object's Boolean value, else null
+     */
+    public static Boolean makeBoolean( Object object )
+    {
         if ( object instanceof Boolean )
         {
-            return castBooleanObject( (Boolean) object, clazz );
+            return (Boolean) object;
         }
 
-        try
+        if ( object instanceof Double && (Double) object % 1 == 0 )
         {
-            return clazz.cast( object );
+            return (Double) object != 0.0;
         }
-        catch ( Exception e )
+
+        if ( object instanceof String )
         {
-            throw new ParserExceptionWithoutContext( "Could not cast value to " + clazz.getSimpleName() );
+            if ( "true".equalsIgnoreCase( (String) object ) )
+            {
+                return true;
+            }
+
+            if ( "false".equalsIgnoreCase( (String) object ) )
+            {
+                return false;
+            }
         }
+
+        return null;
     }
 
-    private static Object castBooleanObject( Boolean object, Class<?> clazz )
+    /**
+     * Makes object a Date, if it can be done.
+     *
+     * @param object object to convert
+     * @return object's Date value, else null
+     */
+    public static Date makeDate( Object object )
     {
-        if (clazz == String.class)
+        if ( object instanceof Date )
         {
-            return object.toString();
+            return (Date) object;
         }
-        else if (clazz == Boolean.class )
-        {
-            return object;
-        }
-        else
-        {
-            throw new ParserExceptionWithoutContext( "Found boolean value when expecting " + clazz.getSimpleName() );
-        }
-    }
-
-    private static Object castStringObject( String object, Class<?> clazz )
-    {
-        if ( clazz == Date.class )
+        if ( object instanceof String )
         {
             try
             {
-                return parseDate( object );
+                return parseDate( (String) object );
             }
             catch ( Exception e )
             {
-                throw new ParserExceptionWithoutContext( "Found '" + object + "' when expecting a date" );
+                return null;
             }
         }
-        else if ( clazz == Double.class )
-        {
-            try
-            {
-                return Double.parseDouble( object );
-            }
-            catch ( Exception e )
-            {
-                throw new ParserExceptionWithoutContext( "Found '" + object + "' when expecting a number" );
-            }
-        }
-        else if ( clazz == Boolean.class )
-        {
-            try
-            {
-                return Boolean.parseBoolean( object );
-            }
-            catch ( Exception e )
-            {
-                throw new ParserExceptionWithoutContext( "Found '" + object + "' when expecting a boolean" );
-            }
-        }
-        else if ( clazz == String.class )
-        {
-            return object;
-        }
-        else
-        {
-            throw new ParserExceptionWithoutContext( "Found string when expecting " + clazz.getSimpleName() );
-        }
+
+        return null;
     }
 
-    private static Object castDoubleObject( Double object, Class<?> clazz )
+    /**
+     * Makes object a String.
+     *
+     * @param object object to convert
+     * @return object's String value
+     */
+    public static String makeString( Object object )
     {
-        if ( clazz == String.class )
-        {
-            return object.toString();
-        }
-        else if ( clazz == Boolean.class && object % 1 == 0 )
-        {
-            return object != 0.0;
-        }
-        else if ( clazz != Double.class )
-        {
-            throw new ParserExceptionWithoutContext( "Found number when expecting " + clazz.getSimpleName() );
-        }
-        return clazz.cast( object );
+        return object.toString();
     }
 }

--- a/src/main/java/org/hisp/dhis/antlr/AntlrParserUtils.java
+++ b/src/main/java/org/hisp/dhis/antlr/AntlrParserUtils.java
@@ -193,19 +193,21 @@ public class AntlrParserUtils
             return null;
         }
 
-        if ( clazz == Double.class && makeDouble( object ) != null )
+        Object result;
+
+        if ( clazz == Double.class && ( result = makeDouble( object ) ) != null )
         {
-            return makeDouble( object );
+            return result;
         }
 
-        if ( clazz == Boolean.class && makeBoolean( object ) != null )
+        if ( clazz == Boolean.class && ( result = makeBoolean( object ) ) != null )
         {
-            return makeBoolean( object );
+            return result;
         }
 
-        if ( clazz == Date.class && makeDate( object ) != null )
+        if ( clazz == Date.class && ( result = makeDate( object ) ) != null )
         {
-            return makeDate( object );
+            return result;
         }
 
         if ( clazz == String.class )

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompare.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompare.java
@@ -53,14 +53,20 @@ public abstract class AntlrOperatorCompare
         Object o1 = values.get( 0 );
         Object o2 = values.get( 1 );
 
-        if ( makeDouble( o1 ) != null && makeDouble( o2 ) != null )
+        Double d1;
+        Double d2;
+
+        if ( ( d1 = makeDouble( o1 ) ) != null && ( d2 = makeDouble( o2 ) ) != null )
         {
-            return ( makeDouble( o1 ) ).compareTo( makeDouble( o2 ) );
+            return ( d1.compareTo( d2 ) );
         }
 
-        if ( makeBoolean( o1 ) != null && makeBoolean( o2 ) != null )
+        Boolean b1;
+        Boolean b2;
+
+        if ( ( b1 = makeBoolean( o1 ) ) != null && ( b2 = makeBoolean( o2 ) ) != null )
         {
-            return ( makeBoolean( o1 ) ).compareTo( makeBoolean( o2 ) );
+            return ( b1.compareTo( b2 ) );
         }
 
         return ( makeString( o1 ) ).compareTo( makeString( o2 ) );

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompare.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompare.java
@@ -28,6 +28,8 @@ package org.hisp.dhis.antlr.operator;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
+
 import java.util.List;
 
 import static org.hisp.dhis.antlr.AntlrParserUtils.makeBoolean;
@@ -46,7 +48,7 @@ public abstract class AntlrOperatorCompare
      * Compares two Doubles, Booleans, or Strings.
      *
      * @param values the values to compare
-     * @return the results of the comparision.
+     * @return the results of the comparison.
      */
     protected int compare( List<Object> values )
     {
@@ -56,25 +58,36 @@ public abstract class AntlrOperatorCompare
         Double d1;
         Double d2;
 
-        if ( ( d1 = makeDouble( o1 ) ) != null && ( d2 = makeDouble( o2 ) ) != null )
+        if ( ( o1 instanceof Double || o2 instanceof Double ) &&
+            ( d1 = makeDouble( o1 ) ) != null &&
+            ( d2 = makeDouble( o2 ) ) != null )
         {
-            return ( d1.compareTo( d2 ) );
+            return d1.compareTo( d2 );
         }
 
         Boolean b1;
         Boolean b2;
 
-        if ( ( b1 = makeBoolean( o1 ) ) != null && ( b2 = makeBoolean( o2 ) ) != null )
+        if ( ( o1 instanceof Boolean || o2 instanceof Boolean ) &&
+            ( b1 = makeBoolean( o1 ) ) != null &&
+            ( b2 = makeBoolean( o2 ) ) != null )
         {
-            return ( b1.compareTo( b2 ) );
+            return b1.compareTo( b2 );
         }
 
-        return ( makeString( o1 ) ).compareTo( makeString( o2 ) );
+        if ( o1 instanceof String || o2 instanceof String )
+        {
+            return makeString( o1 ).compareTo( makeString( o2 ) );
+        }
+
+        throw new ParserExceptionWithoutContext( "Could not compare " +
+            o1.getClass().getSimpleName() + " '" + o1 + "' to " +
+            o2.getClass().getSimpleName() + " '" + o2 + "'" );
     }
 
     /**
      * For a comparison, if any argument value is null, return null.
-     * (If any arguemnt is Double.NaN, the comparison should proceed and
+     * (If any argument is Double.NaN, the comparison should proceed and
      * return a Boolean value.)
      */
     @Override

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompare.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompare.java
@@ -28,12 +28,11 @@ package org.hisp.dhis.antlr.operator;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.apache.commons.lang3.math.NumberUtils;
-import org.hisp.dhis.antlr.InternalParserException;
-
 import java.util.List;
 
-import static org.hisp.dhis.antlr.AntlrParserUtils.*;
+import static org.hisp.dhis.antlr.AntlrParserUtils.makeBoolean;
+import static org.hisp.dhis.antlr.AntlrParserUtils.makeDouble;
+import static org.hisp.dhis.antlr.AntlrParserUtils.makeString;
 
 /**
  * Abstract class for compare operators
@@ -44,7 +43,7 @@ public abstract class AntlrOperatorCompare
     extends AntlrComputeFunction
 {
     /**
-     * Compares two Doubles, Strings or Booleans.
+     * Compares two Doubles, Booleans, or Strings.
      *
      * @param values the values to compare
      * @return the results of the comparision.
@@ -54,30 +53,17 @@ public abstract class AntlrOperatorCompare
         Object o1 = values.get( 0 );
         Object o2 = values.get( 1 );
 
-        if ( o1 == null || o2 == null )
+        if ( makeDouble( o1 ) != null && makeDouble( o2 ) != null )
         {
-            throw new InternalParserException( "found null when comparing '" + o1 + "' with '" + o2 + "'" );
+            return ( makeDouble( o1 ) ).compareTo( makeDouble( o2 ) );
         }
-        else if ( o1 instanceof Double  )
+
+        if ( makeBoolean( o1 ) != null && makeBoolean( o2 ) != null )
         {
-            return ((Double) o1).compareTo( castDouble( o2 ) );
+            return ( makeBoolean( o1 ) ).compareTo( makeBoolean( o2 ) );
         }
-        else if ( o1 instanceof String && NumberUtils.isCreatable((String) o1))
-        {
-            return Double.valueOf((String) o1).compareTo( castDouble( o2 ) );
-        }
-        else if ( o1 instanceof String )
-        {
-            return ((String) o1).compareTo( castString( o2 ) );
-        }
-        else if ( o1 instanceof Boolean )
-        {
-            return ((Boolean) o1).compareTo( castBoolean( o2 ) );
-        }
-        else
-        {
-            throw new InternalParserException( "trying to compare class " + o1.getClass().getName() );
-        }
+
+        return ( makeString( o1 ) ).compareTo( makeString( o2 ) );
     }
 
     /**

--- a/src/test/java/org/hisp/dhis/antlr/CompareExpressionTest.java
+++ b/src/test/java/org/hisp/dhis/antlr/CompareExpressionTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertEquals;
 @RunWith( JUnit4.class )
 public class CompareExpressionTest
 {
-
     private TestExpressionVisitor visitor = new TestExpressionVisitor();
 
     @Test
@@ -17,10 +16,13 @@ public class CompareExpressionTest
         assertEquals( true, evaluate( "'2' > 1" ) );
         assertEquals( false, evaluate( "1 > '2'" ) );
         assertEquals( false, evaluate( "'1' > '2'" ) );
+        assertEquals( true, evaluate( "'10' > '2'" ) );
         assertEquals( true, evaluate( "'1' > '-2'" ) );
         assertEquals( true, evaluate( "'-1' > '-2'" ) );
         assertEquals( false, evaluate( "'-1' > '2'" ) );
         assertEquals( false, evaluate( "'2' > ( 1 + 1 )" ) );
+        assertEquals( true, evaluate( "true > 0" ) );
+        assertEquals( false, evaluate( "false > 1" ) );
     }
 
     @Test
@@ -28,6 +30,10 @@ public class CompareExpressionTest
         assertEquals( true, evaluate( "2 > 1" ) );
         assertEquals( false, evaluate( "1 > 2" ) );
         assertEquals( false, evaluate( "2 > ( 1 + 1 )" ) );
+        assertEquals( true, evaluate( "true > false" ) );
+        assertEquals( false, evaluate( "true > true" ) );
+        assertEquals( false, evaluate( "'abc' > 'abc'" ) );
+        assertEquals( false, evaluate( "'abc' > 'def'" ) );
     }
 
     @Test
@@ -35,6 +41,10 @@ public class CompareExpressionTest
         assertEquals( true, evaluate( "2 >= 1" ) );
         assertEquals( false, evaluate( "1 >= 2" ) );
         assertEquals( true, evaluate( "2 >= ( 1 + 1 )" ) );
+        assertEquals( true, evaluate( "true >= false" ) );
+        assertEquals( true, evaluate( "true >= true" ) );
+        assertEquals( true, evaluate( "'abc' >= 'abc'" ) );
+        assertEquals( false, evaluate( "'abc' >= 'def'" ) );
     }
 
     @Test
@@ -42,6 +52,10 @@ public class CompareExpressionTest
         assertEquals( false, evaluate( "2 < 1" ) );
         assertEquals( true, evaluate( "1 < 2" ) );
         assertEquals( false, evaluate( "2 < ( 1 + 1 )" ) );
+        assertEquals( false, evaluate( "true < false" ) );
+        assertEquals( false, evaluate( "true < true" ) );
+        assertEquals( false, evaluate( "'abc' < 'abc'" ) );
+        assertEquals( true, evaluate( "'abc' < 'def'" ) );
     }
 
     @Test
@@ -49,6 +63,10 @@ public class CompareExpressionTest
         assertEquals( false, evaluate( "2 <= 1" ) );
         assertEquals( true, evaluate( "1 <= 2" ) );
         assertEquals( true, evaluate( "2 <= ( 1 + 1 )" ) );
+        assertEquals( false, evaluate( "true <= false" ) );
+        assertEquals( true, evaluate( "true <= true" ) );
+        assertEquals( true, evaluate( "'abc' <= 'abc'" ) );
+        assertEquals( true, evaluate( "'abc' <= 'def'" ) );
     }
 
     @Test
@@ -82,5 +100,4 @@ public class CompareExpressionTest
     private Object evaluate(String expression) {
         return Parser.visit( expression, visitor );
     }
-
 }

--- a/src/test/java/org/hisp/dhis/antlr/CompareExpressionTest.java
+++ b/src/test/java/org/hisp/dhis/antlr/CompareExpressionTest.java
@@ -1,6 +1,8 @@
 package org.hisp.dhis.antlr;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -10,6 +12,9 @@ import static org.junit.Assert.assertEquals;
 public class CompareExpressionTest
 {
     private TestExpressionVisitor visitor = new TestExpressionVisitor();
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testGreaterForDifferentTypes() {
@@ -94,6 +99,14 @@ public class CompareExpressionTest
     @Test
     public void testDivideByZero() {
         assertEquals( false, evaluate( "2 == 2 / 0" ) );
+    }
+
+    @Test
+    public void testIncompatibleTypes() {
+        exception.expect( ParserException.class );
+        exception.expectMessage("Could not compare Double '2.1' to Boolean 'false'" );
+
+        evaluate( "2.1 == false" );
     }
 
     private Object evaluate(String expression) {

--- a/src/test/java/org/hisp/dhis/antlr/CompareExpressionTest.java
+++ b/src/test/java/org/hisp/dhis/antlr/CompareExpressionTest.java
@@ -15,11 +15,10 @@ public class CompareExpressionTest
     public void testGreaterForDifferentTypes() {
         assertEquals( true, evaluate( "'2' > 1" ) );
         assertEquals( false, evaluate( "1 > '2'" ) );
-        assertEquals( false, evaluate( "'1' > '2'" ) );
-        assertEquals( true, evaluate( "'10' > '2'" ) );
-        assertEquals( true, evaluate( "'1' > '-2'" ) );
-        assertEquals( true, evaluate( "'-1' > '-2'" ) );
-        assertEquals( false, evaluate( "'-1' > '2'" ) );
+        assertEquals( false, evaluate( "'10' > '2'" ) );
+        assertEquals( true, evaluate( "10 > '2'" ) );
+        assertEquals( true, evaluate( "'1' > -2" ) );
+        assertEquals( true, evaluate( "'-10' < -1" ) );
         assertEquals( false, evaluate( "'2' > ( 1 + 1 )" ) );
         assertEquals( true, evaluate( "true > 0" ) );
         assertEquals( false, evaluate( "false > 1" ) );


### PR DESCRIPTION
### Symptom

Sometimes the validity of data types in a comparison depends on which argument is on the left and which is on the right. In the example given by [DHIS2-12105](https://jira.dhis2.org/browse/DHIS2-12105), this comparison returns the parsing error "Found 'mKxKBtIDl6q' when expecting a number":

`V{program_stage_id} != 'mKxKBtIDl6q'`

whereas reversing the arguments produces a valid expression:

`'mKxKBtIDl6q' != V{program_stage_id}`

Note that this would not be a problem if V{program_stage_id} returned a dummy String value when validating the expression. This PR does not address this, but addresses the asymmetry in type conversion between the left and right sides of a comparison.

### Analysis

The asymmetry is caused by the way `AntlrOperatorCompare` has been processing the argument types. It finds the type of the first argument and then sees if the second argument can be converted to match the first. But it does not do the reverse: given the type of the second argument, see if the second argument be converted to match the first.

Also, the type conversions for comparisons are not necessarily the same as the type conversions in the cast methods in `AntlrParserUtils`. For example, `castDoubleObject` converts an integer to a boolean, but in a comparison there has been no ability to compare a boolean with an integer, or an integer with a boolean.

Type conversions should be consistent between both sides of a comparison operator, and should be consistent between comparisons and casting.

### Fix

`AntlrOperatorCompare` has been refactored to make the type conversions the same on both sides of a comparison operator.

`AntlrParserUtils.castClass` used to call private methods based on the data type of the object being considered: `castDoubleObject`, `castStringObject`, and `castBooleanObject`. These methods contained any logic needed to convert the object into the desired class.

The `AntlrParserUtils.castClass` logic has been inverted. Instead of calling helper methods based on the object type, it now calls methods based on the class to cast to: `makeDouble`, `makeBoolean`, `makeDate`, and `makeString`. These  are now public methods, and the same `makeDouble`, `makeBoolean`, and `makeString` methods are now called from `AntlrOperatorCompare`. This insures that the type conversions done for comparisons will be the same logic (because they are the same code) as the type conversions for casting.

### Test

Cross-type comparison tests have been added to `CompareExpressionTest` to test all the type conversions.
