### PR TITLE
fix: count(distinct... custom aggreg. DHIS2-11327

### DIFF
--- a/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
+++ b/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
@@ -51,7 +51,7 @@ expr
     //  Aggergation functions (alphabetical)
 
     |   it='avg(' expr ')'
-    |   it='count(' expr ')'
+    |   it='count(' (WS* distinct='distinct')? expr ')'
     |   it='max(' expr ')'
     |   it='median(' expr ')'
     |   it='min(' expr ')'


### PR DESCRIPTION
See [DHIS2-11327](https://jira.dhis2.org/browse/DHIS2-11327). We need to support the `distinct` keyword inside a custom aggregation type of `count(...`.

Placing the keyword in the grammar will allow it to be processed in the backend DHIS2 code, and the 'distinct' qualifier added to the SQL query.

### Test

I have tested a build of this code with the DHIS2 backend in the debugger. I can see the `distinct` field inside the parsing context. It is null when the keyword is absent in an expression, and non-null when it is present.