### PR TITLE
chore: Upgrade to 1.0.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <name>DHIS Antlr Expression Parser</name>
   <groupId>org.hisp.dhis.parser</groupId>
-  <version>1.0.20-SNAPSHOT</version>
+  <version>1.0.20</version>
 
   <description>Antlr Expression Parser</description>
 


### PR DESCRIPTION
Bump version so DHIS2-11327, DHIS2-12089, and DHIS2-12105 can be fixed in DHIS2.