### PR TITLE
feat: Add .maxDate() and .minDate() DHIS2-9831

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <name>DHIS Antlr Expression Parser</name>
   <groupId>org.hisp.dhis.parser</groupId>
-  <version>1.0.24-SNAPSHOT</version>
+  <version>1.0.24</version>
 
   <description>Antlr Expression Parser</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <name>DHIS Antlr Expression Parser</name>
   <groupId>org.hisp.dhis.parser</groupId>
-  <version>1.0.23</version>
+  <version>1.0.24-SNAPSHOT</version>
 
   <description>Antlr Expression Parser</description>
 

--- a/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
+++ b/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
@@ -22,6 +22,8 @@ expr
 
     //  Dot notation functions (alphabetical)
 
+    |   expr it= '.maxDate(' WS* maxDate=DATE_LITERAL WS* ')'
+    |   expr it= '.minDate(' WS* minDate=DATE_LITERAL WS* ')'
     |   expr it= '.periodOffset(' WS* period=integerLiteral WS* ')'
     |   expr it= '.stageOffset(' WS* stage=integerLiteral WS* ')'
 
@@ -235,6 +237,8 @@ PAREN : '(';
 
 // Dot notation functions (alphabetical)
 
+MAX_DATE        : '.maxDate(';
+MIN_DATE        : '.minDate(';
 PERIOD_OFFSET   : '.periodOffset(';
 STAGE_OFFSET    : '.stageOffset(';
 
@@ -398,6 +402,10 @@ NUMERIC_LITERAL
 BOOLEAN_LITERAL
     :   'true'
     |   'false'
+    ;
+
+DATE_LITERAL
+    :   [1-9] [0-9] [0-9] [0-9] '-' [0-1]? [0-9] '-' [0-3]? [0-9]
     ;
 
 // Quoted UID could also be a string literal. It must come first.


### PR DESCRIPTION
See [DHIS2-9831](https://jira.dhis2.org/browse/DHIS2-9831). Adds the dot functions .maxDate() and .minDate().

The month and day parts of the date can be 1 or 2 digits. (The date will be further validated in the Java code.)