### PR TITLE
feat: is( X in A, B, ... ) [DHIS2-14452]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <name>DHIS Antlr Expression Parser</name>
   <groupId>org.hisp.dhis.parser</groupId>
-  <version>1.0.30</version>
+  <version>1.0.31-SNAPSHOT</version>
 
   <description>Antlr Expression Parser</description>
 

--- a/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
+++ b/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
@@ -45,6 +45,7 @@ expr
     |   it='firstNonNull(' expr (',' expr )* ')'
     |   it='greatest(' expr (',' expr )* ')'
     |   it='if(' expr ',' expr ',' expr ')'
+    |   it='is(' expr 'in' expr (',' expr )* ')'
     |   it='isNotNull(' expr ')'
     |   it='isNull(' expr ')'
     |   it='least(' expr (',' expr )* ')'
@@ -281,6 +282,7 @@ VERTICAL_BAR_2      : '||';
 FIRST_NON_NULL  : 'firstNonNull(';
 GREATEST        : 'greatest(';
 IF              : 'if(';
+IS              : 'is(';
 IS_NOT_NULL     : 'isNotNull(';
 IS_NULL         : 'isNull(';
 LEAST           : 'least(';


### PR DESCRIPTION
See [DHIS2-14452](https://dhis2.atlassian.net/browse/DHIS2-14452), especially [this comment for the syntax](https://dhis2.atlassian.net/browse/DHIS2-14452?focusedCommentId=180081).

This PR adds the expression syntax:

`is( {expr1} in {expr2}, ... )`

which can be evaluated in the backend or translated to generate the SQL:

`{expr1} in ( {expr2}, ... )`