### PR TITLE
feat: is( X in A, B, ... ) take 2 [DHIS2-14452]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <name>DHIS Antlr Expression Parser</name>
   <groupId>org.hisp.dhis.parser</groupId>
-  <version>1.0.31</version>
+  <version>1.0.32-SNAPSHOT</version>
 
   <description>Antlr Expression Parser</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <name>DHIS Antlr Expression Parser</name>
   <groupId>org.hisp.dhis.parser</groupId>
-  <version>1.0.32-SNAPSHOT</version>
+  <version>1.0.32</version>
 
   <description>Antlr Expression Parser</description>
 

--- a/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
+++ b/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
@@ -45,7 +45,7 @@ expr
     |   it='firstNonNull(' expr (',' expr )* ')'
     |   it='greatest(' expr (',' expr )* ')'
     |   it='if(' expr ',' expr ',' expr ')'
-    |   it='is(' expr 'in' expr (',' expr )* ')'
+    |   it='is(' expr WS 'in' WS expr (',' expr )* ')'
     |   it='isNotNull(' expr ')'
     |   it='isNull(' expr ')'
     |   it='least(' expr (',' expr )* ')'

--- a/src/main/java/org/hisp/dhis/antlr/AntlrParserUtils.java
+++ b/src/main/java/org/hisp/dhis/antlr/AntlrParserUtils.java
@@ -44,11 +44,11 @@ import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.*;
  */
 public class AntlrParserUtils
 {
-    public final static double DOUBLE_VALUE_IF_NULL = 0.0;
+    public static final double DOUBLE_VALUE_IF_NULL = 0.0;
 
-    public final static boolean BOOLEAN_VALUE_IF_NULL = false;
+    public static final boolean BOOLEAN_VALUE_IF_NULL = false;
 
-    public final static ImmutableMap<Integer, AntlrExprItem> ANTLR_EXPRESSION_ITEMS = ImmutableMap.<Integer, AntlrExprItem>builder()
+    public static final ImmutableMap<Integer, AntlrExprItem> ANTLR_EXPRESSION_ITEMS = ImmutableMap.<Integer, AntlrExprItem>builder()
 
         // Functions
 
@@ -82,6 +82,11 @@ public class AntlrParserUtils
 
         .build();
 
+    private AntlrParserUtils()
+    {
+        throw new UnsupportedOperationException( "util" );
+    }
+
     /**
      * Trim quotes from the first and last characters of a string.
      * The string must be at least two characters long.
@@ -102,6 +107,45 @@ public class AntlrParserUtils
         }
 
         return str.substring(1, str.length() - 1);
+    }
+
+    /**
+     * Compares two Doubles, Booleans, or Strings.
+     *
+     * @param o1 the first value to compare
+     * @param o2 the second value to compare
+     * @return the results of the comparison
+     */
+    public static int compare( Object o1, Object o2 )
+    {
+        Double d1;
+        Double d2;
+
+        if ( ( o1 instanceof Double || o2 instanceof Double ) &&
+            ( d1 = makeDouble( o1 ) ) != null &&
+            ( d2 = makeDouble( o2 ) ) != null )
+        {
+            return d1.compareTo( d2 );
+        }
+
+        Boolean b1;
+        Boolean b2;
+
+        if ( ( o1 instanceof Boolean || o2 instanceof Boolean ) &&
+            ( b1 = makeBoolean( o1 ) ) != null &&
+            ( b2 = makeBoolean( o2 ) ) != null )
+        {
+            return b1.compareTo( b2 );
+        }
+
+        if ( o1 instanceof String || o2 instanceof String )
+        {
+            return makeString( o1 ).compareTo( makeString( o2 ) );
+        }
+
+        throw new ParserExceptionWithoutContext( "Could not compare " +
+            o1.getClass().getSimpleName() + " '" + o1 + "' to " +
+            o2.getClass().getSimpleName() + " '" + o2 + "'" );
     }
 
     /**

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompare.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompare.java
@@ -28,14 +28,6 @@ package org.hisp.dhis.antlr.operator;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
-
-import java.util.List;
-
-import static org.hisp.dhis.antlr.AntlrParserUtils.makeBoolean;
-import static org.hisp.dhis.antlr.AntlrParserUtils.makeDouble;
-import static org.hisp.dhis.antlr.AntlrParserUtils.makeString;
-
 /**
  * Abstract class for compare operators
  *
@@ -44,47 +36,6 @@ import static org.hisp.dhis.antlr.AntlrParserUtils.makeString;
 public abstract class AntlrOperatorCompare
     extends AntlrComputeFunction
 {
-    /**
-     * Compares two Doubles, Booleans, or Strings.
-     *
-     * @param values the values to compare
-     * @return the results of the comparison.
-     */
-    protected int compare( List<Object> values )
-    {
-        Object o1 = values.get( 0 );
-        Object o2 = values.get( 1 );
-
-        Double d1;
-        Double d2;
-
-        if ( ( o1 instanceof Double || o2 instanceof Double ) &&
-            ( d1 = makeDouble( o1 ) ) != null &&
-            ( d2 = makeDouble( o2 ) ) != null )
-        {
-            return d1.compareTo( d2 );
-        }
-
-        Boolean b1;
-        Boolean b2;
-
-        if ( ( o1 instanceof Boolean || o2 instanceof Boolean ) &&
-            ( b1 = makeBoolean( o1 ) ) != null &&
-            ( b2 = makeBoolean( o2 ) ) != null )
-        {
-            return b1.compareTo( b2 );
-        }
-
-        if ( o1 instanceof String || o2 instanceof String )
-        {
-            return makeString( o1 ).compareTo( makeString( o2 ) );
-        }
-
-        throw new ParserExceptionWithoutContext( "Could not compare " +
-            o1.getClass().getSimpleName() + " '" + o1 + "' to " +
-            o2.getClass().getSimpleName() + " '" + o2 + "'" );
-    }
-
     /**
      * For a comparison, if any argument value is null, return null.
      * (If any argument is Double.NaN, the comparison should proceed and

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareEqual.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareEqual.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.antlr.operator;
 
 import java.util.List;
 
+import static org.hisp.dhis.antlr.AntlrParserUtils.compare;
+
 /**
  * Compare operator: equal
  *
@@ -42,6 +44,6 @@ public class AntlrOperatorCompareEqual
     @Override
     public Object compute( List<Object> values )
     {
-        return compare( values ) == 0;
+        return compare( values.get( 0 ), values.get( 1 ) ) == 0;
     }
 }

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareGreaterThan.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareGreaterThan.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.antlr.operator;
 
 import java.util.List;
 
+import static org.hisp.dhis.antlr.AntlrParserUtils.compare;
+
 /**
  * Compare operator: greater than
  *
@@ -41,6 +43,6 @@ public class AntlrOperatorCompareGreaterThan
     @Override
     public Object compute( List<Object> values )
     {
-        return compare( values ) > 0;
+        return compare( values.get( 0 ), values.get( 1 ) ) > 0;
     }
 }

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareGreaterThanOrEqual.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareGreaterThanOrEqual.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.antlr.operator;
 
 import java.util.List;
 
+import static org.hisp.dhis.antlr.AntlrParserUtils.compare;
+
 /**
  * Compare operator: greater than or equal
  *
@@ -41,6 +43,6 @@ public class AntlrOperatorCompareGreaterThanOrEqual
     @Override
     public Object compute( List<Object> values )
     {
-        return compare( values ) >= 0;
+        return compare( values.get( 0 ), values.get( 1 ) ) >= 0;
     }
 }

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareLessThan.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareLessThan.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.antlr.operator;
 
 import java.util.List;
 
+import static org.hisp.dhis.antlr.AntlrParserUtils.compare;
+
 /**
  * Compare operator: less than
  *
@@ -41,6 +43,6 @@ public class AntlrOperatorCompareLessThan
     @Override
     public Object compute( List<Object> values )
     {
-        return compare( values ) < 0;
+        return compare( values.get( 0 ), values.get( 1 ) ) < 0;
     }
 }

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareLessThanOrEqual.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareLessThanOrEqual.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.antlr.operator;
 
 import java.util.List;
 
+import static org.hisp.dhis.antlr.AntlrParserUtils.compare;
+
 /**
  * Compare operator: less than or equal
  *
@@ -41,6 +43,6 @@ public class AntlrOperatorCompareLessThanOrEqual
     @Override
     public Object compute( List<Object> values )
     {
-        return compare( values ) <= 0;
+        return compare( values.get( 0 ), values.get( 1 ) ) <= 0;
     }
 }

--- a/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareNotEqual.java
+++ b/src/main/java/org/hisp/dhis/antlr/operator/AntlrOperatorCompareNotEqual.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.antlr.operator;
 
 import java.util.List;
 
+import static org.hisp.dhis.antlr.AntlrParserUtils.compare;
+
 /**
  * Compare operator: not equal
  *
@@ -41,6 +43,6 @@ public class AntlrOperatorCompareNotEqual
     @Override
     public Object compute( List<Object> values )
     {
-        return compare( values ) != 0;
+        return compare( values.get( 0 ), values.get( 1 ) ) != 0;
     }
 }


### PR DESCRIPTION
Second PR for [DHIS2-14452](https://dhis2.atlassian.net/browse/DHIS2-14452):

1. Require at least one whitespace character before and after the `in` keyword in the `is` function. It turns out that Postgres accepts syntax like `select 1in(1,2)` but I don't think it's a good idea for us to start allowing expression syntax like `is(1in1,2)`. We can always loosen this restriction later if we feel differently, but it would be a breaking change to add this restriction later if we don't require it now.
2. Move the `compare` method from `AntlrOperatorCompare` to `AntlrParserUtils`. This will allow core code for the `is` function to use the same logic to test for equality that the comparison functions use, so that `is(X in Y,Z)` will function identically to `(X==Y or X==Z)` The `is` function will be a common logic function like `if`, `isNull`, `greatest`, `least`, `firstNonNull`, etc., that will be not just be supported for program indicators but also for indicators, validation rules, and predictors.
3. Fix a couple of things in `AntlrParserUtils` that SonarLint didn't like: Add a private constructor, reorder `static final` modifiers.

[DHIS2-14452]: https://dhis2.atlassian.net/browse/DHIS2-14452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ