### PR TITLE
feat: Predictor norm. dist. functions [DHIS2-14714]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <name>DHIS Antlr Expression Parser</name>
   <groupId>org.hisp.dhis.parser</groupId>
-  <version>1.0.33-SNAPSHOT</version>
+  <version>1.0.33</version>
 
   <description>Antlr Expression Parser</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <name>DHIS Antlr Expression Parser</name>
   <groupId>org.hisp.dhis.parser</groupId>
-  <version>1.0.32</version>
+  <version>1.0.33-SNAPSHOT</version>
 
   <description>Antlr Expression Parser</description>
 

--- a/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
+++ b/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
@@ -51,6 +51,8 @@ expr
     |   it='least(' expr (',' expr )* ')'
     |   it='log(' expr (',' expr )? ')'
     |   it='log10(' expr ')'
+    |   it='normDistCum(' expr (',' expr )? (',' expr )? ')'
+    |   it='normDistDen(' expr (',' expr )? (',' expr )? ')'
     |   it='orgUnit.ancestor(' WS* UID WS* (',' WS* UID WS* )* ')'
     |   it='orgUnit.dataSet(' WS* UID WS* (',' WS* UID WS* )* ')'
     |   it='orgUnit.group(' WS* UID WS* (',' WS* UID WS* )* ')'
@@ -288,6 +290,8 @@ IS_NULL         : 'isNull(';
 LEAST           : 'least(';
 LOG             : 'log(';
 LOG10           : 'log10(';
+NORM_DIST_CUM   : 'normDistCum(';
+NORM_DIST_DEN   : 'normDistDen(';
 ORGUNIT_ANCESTOR: 'orgUnit.ancestor(';
 ORGUNIT_DATASET : 'orgUnit.dataSet(';
 ORGUNIT_GROUP   : 'orgUnit.group(';


### PR DESCRIPTION
See [DHIS2-14714](https://dhis2.atlassian.net/browse/DHIS2-14714).

This adds two predictor functions used with normalized distributions: _normDistCum()_ and _normDistDen()_.

[DHIS2-14714]: https://dhis2.atlassian.net/browse/DHIS2-14714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ