### PR TITLE
ci: update pgp secrets in master workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,6 +41,6 @@ jobs:
         with:
           nexus_username: ${{ secrets.nexus_username }}
           nexus_password: ${{ secrets.nexus_password }}
-          gpg_private_key: ${{ secrets.gpg_private_key }}
-          gpg_passphrase: ${{ secrets.gpg_passphrase }}
+          gpg_private_key: ${{ secrets.PGP_PRIVATE_KEY }}
+          gpg_passphrase: ${{ secrets.PGP_PASSPHRASE }}
           maven_profiles: "master"


### PR DESCRIPTION
Changing from the old Repository based secrets to the new Organization based ones should fix this maven release failure in the `master` workflow - https://github.com/dhis2/dhis2-antlr-expression-parser/actions/runs/7641296602/job/20952982943#step:5:1563


