### PR TITLE
feat: contains and containsItems [DHIS2-16211]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <name>DHIS Antlr Expression Parser</name>
   <groupId>org.hisp.dhis.parser</groupId>
-  <version>1.0.36-SNAPSHOT</version>
+  <version>1.0.36</version>
 
   <description>Antlr Expression Parser</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <name>DHIS Antlr Expression Parser</name>
   <groupId>org.hisp.dhis.parser</groupId>
-  <version>1.0.35</version>
+  <version>1.0.36-SNAPSHOT</version>
 
   <description>Antlr Expression Parser</description>
 

--- a/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
+++ b/src/main/antlr4/org/hisp/dhis/parser/expression/antlr/Expression.g4
@@ -47,6 +47,8 @@ expr
 
     //  Functions (alphabetical)
 
+    |   it='contains(' expr (',' expr )+ ')'
+    |   it='containsItems(' expr (',' expr )+ ')'
     |   it='firstNonNull(' expr (',' expr )* ')'
     |   it='greatest(' expr (',' expr )* ')'
     |   it='if(' expr ',' expr ',' expr ')'
@@ -64,7 +66,6 @@ expr
     |   it='orgUnit.program(' WS* UID WS* (',' WS* UID WS* )* ')'
     |   it='removeZeros(' expr ')'
     |   it='subExpression(' expr ')'
-    |   it='textContains(' expr (',' expr )+ ')'
 
     //  Aggergation functions (alphabetical)
 
@@ -292,6 +293,8 @@ VERTICAL_BAR_2      : '||';
 
 // Functions (alphabetical)
 
+CONTAINS        : 'contains(';
+CONTAINS_ITEMS  : 'containsItems(';
 FIRST_NON_NULL  : 'firstNonNull(';
 GREATEST        : 'greatest(';
 IF              : 'if(';
@@ -309,7 +312,6 @@ ORGUNIT_GROUP   : 'orgUnit.group(';
 ORGUNIT_PROGRAM : 'orgUnit.program(';
 REMOVE_ZEROS    : 'removeZeros(';
 SUB_EXPRESSION  : 'subExpression(';
-TEXT_CONTAINS   : 'textContains(';
 
 // Aggegation functions (alphabetical)
 


### PR DESCRIPTION
See [DHIS2-16211](https://dhis2.atlassian.net/browse/DHIS2-16211).

In further discussion, the textContains() syntax was dropped in favor of the two functions contains() and containsItems().

[DHIS2-16211]: https://dhis2.atlassian.net/browse/DHIS2-16211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ