### PR TITLE
chore: Upgrade ANTLR version to 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <rootDir>../../</rootDir>
     <antlr4.visitor>true</antlr4.visitor>
     <antlr4.listener>true</antlr4.listener>
-    <antlr.version>4.9.3</antlr.version>
+    <antlr.version>4.13.2</antlr.version>
     <gpg.skip>true</gpg.skip>
   </properties>
   


### PR DESCRIPTION
Upgrades ANTLR version to 4.13.2. This is required as the ClickHouse JDBC driver used in DHIS2 core depends on ANTLR 4.13.2, and we want a single version of ANTRL in DHIS2 core.